### PR TITLE
Video player UI: speed dropdown, Escape key, mobile layout

### DIFF
--- a/src/components/VideoPlayer/container.tsx
+++ b/src/components/VideoPlayer/container.tsx
@@ -1,4 +1,6 @@
 import { useVideoPlayerContext, useVideoPlayerRefs } from "@lib/contexts/video";
+import { useIsMobile } from "@hooks/use-mobile";
+import { ArrowLeftRight, Smartphone } from "lucide-react";
 import { cn } from "@utils/classMerge";
 import type { ReactElement, FC, PropsWithChildren } from "react";
 import type { VideoPlayerStore } from "@lib/stores/video";
@@ -12,6 +14,7 @@ export function VideoPlayerContainer({
   children,
 }: VideoPlayerContainerProps): ReactElement<FC> {
   const { containerRef } = useVideoPlayerRefs();
+  const isMobile = useIsMobile();
   const isFullscreen = useVideoPlayerContext<boolean>(
     (state: VideoPlayerStore): boolean => state.state.events.isFullscreen,
   );
@@ -20,9 +23,33 @@ export function VideoPlayerContainer({
     "rounded-xl": !isFullscreen,
   });
 
+  if (!isMobile) {
+    return (
+      <div ref={containerRef} className={containerClasses}>
+        {children}
+      </div>
+    );
+  }
+
   return (
-    <div ref={containerRef} className={containerClasses}>
-      {children}
+    <div
+      className={cn(
+        "max-md:relative max-md:left-1/2 max-md:w-screen max-md:max-w-[100vw] max-md:-translate-x-1/2 max-md:bg-black",
+      )}
+    >
+      <div ref={containerRef} className={cn(containerClasses, "max-md:rounded-none")}>
+        {children}
+      </div>
+      <div
+        className="pointer-events-none flex justify-center px-4 py-3 max-md:landscape:hidden"
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2.5 text-center text-sm font-medium text-white/90 backdrop-blur-sm">
+          <Smartphone className="size-5 shrink-0 text-mango-yellow" aria-hidden />
+          <ArrowLeftRight className="size-4 shrink-0 text-mango-yellow/80" aria-hidden />
+          <span>Rotate sideways for full-width video</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/VideoPlayer/container.tsx
+++ b/src/components/VideoPlayer/container.tsx
@@ -18,7 +18,7 @@ export function VideoPlayerContainer({
   const isFullscreen = useVideoPlayerContext<boolean>(
     (state: VideoPlayerStore): boolean => state.state.events.isFullscreen,
   );
-  const containerClasses: string = cn("relative", className, {
+  const containerClasses: string = cn("relative overflow-visible", className, {
     "rounded-none": isFullscreen,
     "rounded-xl": !isFullscreen,
   });

--- a/src/components/VideoPlayer/container.tsx
+++ b/src/components/VideoPlayer/container.tsx
@@ -1,4 +1,5 @@
 import { useVideoPlayerContext, useVideoPlayerRefs } from "@lib/contexts/video";
+import { usingMobilePointer } from "@lib/mobile";
 import { useIsMobile } from "@hooks/use-mobile";
 import { ArrowLeftRight, Smartphone } from "lucide-react";
 import { cn } from "@utils/classMerge";
@@ -14,7 +15,6 @@ export function VideoPlayerContainer({
   children,
 }: VideoPlayerContainerProps): ReactElement<FC> {
   const { containerRef } = useVideoPlayerRefs();
-  const isMobile = useIsMobile();
   const isFullscreen = useVideoPlayerContext<boolean>(
     (state: VideoPlayerStore): boolean => state.state.events.isFullscreen,
   );
@@ -23,7 +23,7 @@ export function VideoPlayerContainer({
     "rounded-xl": !isFullscreen,
   });
 
-  if (!isMobile) {
+  if (!usingMobilePointer() || !useIsMobile()) {
     return (
       <div ref={containerRef} className={containerClasses}>
         {children}
@@ -37,7 +37,10 @@ export function VideoPlayerContainer({
         "max-md:relative max-md:left-1/2 max-md:w-screen max-md:max-w-[100vw] max-md:-translate-x-1/2 max-md:bg-black",
       )}
     >
-      <div ref={containerRef} className={cn(containerClasses, "max-md:rounded-none")}>
+      <div
+        ref={containerRef}
+        className={cn(containerClasses, "max-md:rounded-none")}
+      >
         {children}
       </div>
       <div
@@ -45,8 +48,14 @@ export function VideoPlayerContainer({
         aria-live="polite"
       >
         <div className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2.5 text-center text-sm font-medium text-white/90 backdrop-blur-sm">
-          <Smartphone className="size-5 shrink-0 text-mango-yellow" aria-hidden />
-          <ArrowLeftRight className="size-4 shrink-0 text-mango-yellow/80" aria-hidden />
+          <Smartphone
+            className="size-5 shrink-0 text-mango-yellow"
+            aria-hidden
+          />
+          <ArrowLeftRight
+            className="size-4 shrink-0 text-mango-yellow/80"
+            aria-hidden
+          />
           <span>Rotate sideways for full-width video</span>
         </div>
       </div>

--- a/src/components/VideoPlayer/controls.tsx
+++ b/src/components/VideoPlayer/controls.tsx
@@ -6,7 +6,7 @@ import { Play, Pause, RotateCcw, Volume, Volume1, Volume2, Fullscreen, Gauge } f
 import { Button } from "@components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@components/ui/tooltip";
 import { Slider, TrackSlider } from "@components/ui/slider";
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuPortal, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuLabel, DropdownMenuSeparator } from "@components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuLabel, DropdownMenuSeparator } from "@components/ui/dropdown-menu";
 import { cn } from "@utils/classMerge";
 import { formatTime } from "@utils/format";
 import { VIDEO_PLAYER_VOLUME, PLAYBACK_RATES } from "@utils/constants";
@@ -177,26 +177,21 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
                 </DropdownMenuTrigger>
               }
             />
-            <DropdownMenuPortal
-              container={
-                isFullscreen ? containerRef.current : document.body
-              }
+            <DropdownMenuContent
+              container={containerRef}
+              side="top"
+              align="center"
+              className="min-w-none w-8"
             >
-              <DropdownMenuContent
-                side="top"
-                align="center"
-                className="min-w-none w-8"
-              >
-                <Slider
-                  orientation="vertical"
-                  max={1}
-                  step={0.01}
-                  value={volume}
-                  onValueChange={handleVolumeChange}
-                  className="cursor-pointer"
-                />
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
+              <Slider
+                orientation="vertical"
+                max={1}
+                step={0.01}
+                value={volume}
+                onValueChange={handleVolumeChange}
+                className="cursor-pointer"
+              />
+            </DropdownMenuContent>
           </DropdownMenu>
           <TooltipContent
             className="text-white"
@@ -218,30 +213,25 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
                 </DropdownMenuTrigger>
               }
             />
-            <DropdownMenuPortal
-              container={
-                isFullscreen ? containerRef.current : document.body
-              }
+            <DropdownMenuContent
+              container={containerRef}
+              side="top"
+              align="center"
+              className="min-w-[6rem]"
             >
-              <DropdownMenuContent
-                side="top"
-                align="center"
-                className="min-w-[6rem]"
+              <DropdownMenuLabel>Speed</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuRadioGroup
+                value={String(playbackRate)}
+                onValueChange={handlePlaybackRateChange}
               >
-                <DropdownMenuLabel>Speed</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuRadioGroup
-                  value={String(playbackRate)}
-                  onValueChange={handlePlaybackRateChange}
-                >
-                  {PLAYBACK_RATES.map((rate) => (
-                    <DropdownMenuRadioItem key={rate} value={String(rate)} className="cursor-pointer font-mono text-sm">
-                      {rate === 1 ? "Normal" : `${rate}×`}
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
+                {PLAYBACK_RATES.map((rate) => (
+                  <DropdownMenuRadioItem key={rate} value={String(rate)} className="cursor-pointer font-mono text-sm">
+                    {rate === 1 ? "Normal" : `${rate}×`}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
           </DropdownMenu>
           <TooltipContent
             className="text-white"

--- a/src/components/VideoPlayer/controls.tsx
+++ b/src/components/VideoPlayer/controls.tsx
@@ -2,14 +2,14 @@ import { useCallback, forwardRef } from "react";
 import { useVideoPlayerContext, useVideoPlayerRefs } from "@lib/contexts/video";
 import { usingMobilePointer } from "@lib/mobile";
 import { usePlayToggle } from "@hooks/use-play-toggle";
-import { Play, Pause, RotateCcw, Volume, Volume1, Volume2, Fullscreen } from "lucide-react";
+import { Play, Pause, RotateCcw, Volume, Volume1, Volume2, Fullscreen, Gauge } from "lucide-react";
 import { Button } from "@components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@components/ui/tooltip";
 import { Slider, TrackSlider } from "@components/ui/slider";
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuPortal, DropdownMenuContent } from "@components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuPortal, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuLabel, DropdownMenuSeparator } from "@components/ui/dropdown-menu";
 import { cn } from "@utils/classMerge";
 import { formatTime } from "@utils/format";
-import { VIDEO_PLAYER_VOLUME } from "@utils/constants";
+import { VIDEO_PLAYER_VOLUME, PLAYBACK_RATES } from "@utils/constants";
 import type { ReactElement, FC, PropsWithChildren } from "react";
 import type { VideoPlayerStore, VideoPlayerActions } from "@lib/stores/video";
 
@@ -46,6 +46,8 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
   const isFullscreen = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isFullscreen);
   const isPlaying = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isPlaying);
   const isVolumeMenuOpen = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isVolumeMenuOpen);
+  const isSpeedMenuOpen = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isSpeedMenuOpen);
+  const playbackRate = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.playbackRate);
   const time = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.time);
   const duration = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.duration);
   const volume = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.volume);
@@ -85,6 +87,19 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
   );
   const handleVolumeMenuOpen = useCallback(
     (open: boolean): void => setEvent("isVolumeMenuOpen", open),
+    [],
+  );
+  const handleSpeedMenuOpen = useCallback(
+    (open: boolean): void => setEvent("isSpeedMenuOpen", open),
+    [],
+  );
+  const handlePlaybackRateChange = useCallback(
+    (value: string): void => {
+      if (videoRef.current == null) return;
+      const rate = parseFloat(value);
+      videoRef.current.playbackRate = rate;
+      setValue("playbackRate", rate);
+    },
     [],
   );
   const handleFullscreenToggle = useCallback((): void => {
@@ -190,7 +205,52 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
             Volume
           </TooltipContent>
         </Tooltip>
-        <Tooltip key={isFullscreen ? "fullscreen-toggle:active" : "fullscreen-toggle:inactve"}>
+        <Tooltip disabled={isSpeedMenuOpen}>
+          <DropdownMenu
+            open={isSpeedMenuOpen}
+            onOpenChange={handleSpeedMenuOpen}
+          >
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger render={<VideoControlButton className="font-mono text-xs" />}>
+                  <Gauge className="size-4" />
+                  <span className="ml-1">{playbackRate === 1 ? "1×" : `${playbackRate}×`}</span>
+                </DropdownMenuTrigger>
+              }
+            />
+            <DropdownMenuPortal
+              container={
+                isFullscreen ? containerRef.current : document.body
+              }
+            >
+              <DropdownMenuContent
+                side="top"
+                align="center"
+                className="min-w-[6rem]"
+              >
+                <DropdownMenuLabel>Speed</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuRadioGroup
+                  value={String(playbackRate)}
+                  onValueChange={handlePlaybackRateChange}
+                >
+                  {PLAYBACK_RATES.map((rate) => (
+                    <DropdownMenuRadioItem key={rate} value={String(rate)} className="cursor-pointer font-mono text-sm">
+                      {rate === 1 ? "Normal" : `${rate}×`}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenuPortal>
+          </DropdownMenu>
+          <TooltipContent
+            className="text-white"
+            container={isFullscreen ? containerRef.current : document.body}
+          >
+            Playback Speed
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip key={isFullscreen ? "fullscreen-toggle:active" : "fullscreen-toggle:inactive"}>
           <TooltipTrigger
             render={
               <VideoControlButton onClick={handleFullscreenToggle}>

--- a/src/components/VideoPlayer/controls.tsx
+++ b/src/components/VideoPlayer/controls.tsx
@@ -144,11 +144,11 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
     (open: boolean): void => setEvent("isSpeedMenuOpen", open),
     [],
   );
-  const handlePlaybackRateChange = useCallback((value: string): void => {
+  const handlePlaybackRateChange = useCallback((value: number): void => {
     if (videoRef.current == null) return;
-    const rate = parseFloat(value);
-    videoRef.current.playbackRate = rate;
-    setValue("playbackRate", rate);
+
+    videoRef.current.playbackRate = value;
+    setValue("playbackRate", value);
   }, []);
   const handleFullscreenToggle = useCallback((): void => {
     if (containerRef.current == null) return;
@@ -270,18 +270,20 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
                 <DropdownMenuLabel>Speed</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuRadioGroup
-                  value={String(playbackRate)}
+                  value={playbackRate}
                   onValueChange={handlePlaybackRateChange}
                 >
-                  {PLAYBACK_RATES.map((rate) => (
-                    <DropdownMenuRadioItem
-                      key={rate}
-                      value={String(rate)}
-                      className="cursor-pointer font-mono text-sm"
-                    >
-                      {rate === 1 ? "Normal" : `${rate}×`}
-                    </DropdownMenuRadioItem>
-                  ))}
+                  {PLAYBACK_RATES.map(
+                    (rate: number): ReactElement<FC> => (
+                      <DropdownMenuRadioItem
+                        key={rate}
+                        value={rate}
+                        className="cursor-pointer font-mono text-sm"
+                      >
+                        {rate === 1 ? "Normal" : `${rate}×`}
+                      </DropdownMenuRadioItem>
+                    ),
+                  )}
                 </DropdownMenuRadioGroup>
               </DropdownMenuGroup>
             </DropdownMenuContent>

--- a/src/components/VideoPlayer/controls.tsx
+++ b/src/components/VideoPlayer/controls.tsx
@@ -2,11 +2,33 @@ import { useCallback, forwardRef } from "react";
 import { useVideoPlayerContext, useVideoPlayerRefs } from "@lib/contexts/video";
 import { usingMobilePointer } from "@lib/mobile";
 import { usePlayToggle } from "@hooks/use-play-toggle";
-import { Play, Pause, RotateCcw, Volume, Volume1, Volume2, Fullscreen, Gauge } from "lucide-react";
+import {
+  Play,
+  Pause,
+  RotateCcw,
+  Volume,
+  Volume1,
+  Volume2,
+  Fullscreen,
+  Gauge,
+} from "lucide-react";
 import { Button } from "@components/ui/button";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@components/ui/tooltip";
 import { Slider, TrackSlider } from "@components/ui/slider";
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuLabel, DropdownMenuSeparator } from "@components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@components/ui/dropdown-menu";
 import { cn } from "@utils/classMerge";
 import { formatTime } from "@utils/format";
 import { VIDEO_PLAYER_VOLUME, PLAYBACK_RATES } from "@utils/constants";
@@ -39,19 +61,48 @@ export const VideoControlButton = forwardRef<
 export function VideoPlayerControlBar(): ReactElement<FC> {
   const handlePlayToggle = usePlayToggle();
   const { videoRef, containerRef } = useVideoPlayerRefs();
-  const setEvent = useVideoPlayerContext<VideoPlayerActions["setEvent"]>((store: VideoPlayerStore): VideoPlayerActions["setEvent"] => store.actions.setEvent);
-  const setEvents = useVideoPlayerContext<VideoPlayerActions["setEvents"]>((store: VideoPlayerStore): VideoPlayerActions["setEvents"] => store.actions.setEvents);
-  const setValue = useVideoPlayerContext<VideoPlayerActions["setValue"]>((store: VideoPlayerStore): VideoPlayerActions["setValue"] => store.actions.setValue);
-  const hasEnded = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.hasEnded);
-  const isFullscreen = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isFullscreen);
-  const isPlaying = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isPlaying);
-  const isVolumeMenuOpen = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isVolumeMenuOpen);
-  const isSpeedMenuOpen = useVideoPlayerContext<boolean>((store: VideoPlayerStore): boolean => store.state.events.isSpeedMenuOpen);
-  const playbackRate = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.playbackRate);
-  const time = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.time);
-  const duration = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.duration);
-  const volume = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.volume);
-  const buffered = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.buffered);
+  const setEvent = useVideoPlayerContext<VideoPlayerActions["setEvent"]>(
+    (store: VideoPlayerStore): VideoPlayerActions["setEvent"] =>
+      store.actions.setEvent,
+  );
+  const setEvents = useVideoPlayerContext<VideoPlayerActions["setEvents"]>(
+    (store: VideoPlayerStore): VideoPlayerActions["setEvents"] =>
+      store.actions.setEvents,
+  );
+  const setValue = useVideoPlayerContext<VideoPlayerActions["setValue"]>(
+    (store: VideoPlayerStore): VideoPlayerActions["setValue"] =>
+      store.actions.setValue,
+  );
+  const hasEnded = useVideoPlayerContext<boolean>(
+    (store: VideoPlayerStore): boolean => store.state.events.hasEnded,
+  );
+  const isFullscreen = useVideoPlayerContext<boolean>(
+    (store: VideoPlayerStore): boolean => store.state.events.isFullscreen,
+  );
+  const isPlaying = useVideoPlayerContext<boolean>(
+    (store: VideoPlayerStore): boolean => store.state.events.isPlaying,
+  );
+  const isVolumeMenuOpen = useVideoPlayerContext<boolean>(
+    (store: VideoPlayerStore): boolean => store.state.events.isVolumeMenuOpen,
+  );
+  const isSpeedMenuOpen = useVideoPlayerContext<boolean>(
+    (store: VideoPlayerStore): boolean => store.state.events.isSpeedMenuOpen,
+  );
+  const playbackRate = useVideoPlayerContext<number>(
+    (store: VideoPlayerStore): number => store.state.values.playbackRate,
+  );
+  const time = useVideoPlayerContext<number>(
+    (store: VideoPlayerStore): number => store.state.values.time,
+  );
+  const duration = useVideoPlayerContext<number>(
+    (store: VideoPlayerStore): number => store.state.values.duration,
+  );
+  const volume = useVideoPlayerContext<number>(
+    (store: VideoPlayerStore): number => store.state.values.volume,
+  );
+  const buffered = useVideoPlayerContext<number>(
+    (store: VideoPlayerStore): number => store.state.values.buffered,
+  );
   const handleTrackChange = useCallback(
     (value: number | readonly number[]): void => {
       if (videoRef.current == null) return;
@@ -63,7 +114,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
         setEvents({
           isRestarting: true,
           hasStarted: true,
-          hasEnded: false
+          hasEnded: false,
         });
       }
 
@@ -93,15 +144,12 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
     (open: boolean): void => setEvent("isSpeedMenuOpen", open),
     [],
   );
-  const handlePlaybackRateChange = useCallback(
-    (value: string): void => {
-      if (videoRef.current == null) return;
-      const rate = parseFloat(value);
-      videoRef.current.playbackRate = rate;
-      setValue("playbackRate", rate);
-    },
-    [],
-  );
+  const handlePlaybackRateChange = useCallback((value: string): void => {
+    if (videoRef.current == null) return;
+    const rate = parseFloat(value);
+    videoRef.current.playbackRate = rate;
+    setValue("playbackRate", rate);
+  }, []);
   const handleFullscreenToggle = useCallback((): void => {
     if (containerRef.current == null) return;
 
@@ -129,10 +177,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
         <Tooltip>
           <TooltipTrigger
             render={
-              <VideoControlButton
-                onClick={handlePlayToggle}
-                className="w-20"
-              >
+              <VideoControlButton onClick={handlePlayToggle} className="w-20">
                 {hasEnded && <RotateCcw />}
                 {isPlaying && !hasEnded && <Pause fill="white" />}
                 {!isPlaying && !hasEnded && <Play fill="white" />}
@@ -147,9 +192,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
           </TooltipContent>
         </Tooltip>
         <div className="inline-flex justify-center w-10">
-          <span className="text-white text-sm">
-            {formatTime(time)}
-          </span>
+          <span className="text-white text-sm">{formatTime(time)}</span>
         </div>
       </div>
       <div className="grid items-center">
@@ -207,9 +250,13 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
           >
             <TooltipTrigger
               render={
-                <DropdownMenuTrigger render={<VideoControlButton className="font-mono text-xs" />}>
+                <DropdownMenuTrigger
+                  render={<VideoControlButton className="font-mono text-xs" />}
+                >
                   <Gauge className="size-4" />
-                  <span className="ml-1">{playbackRate === 1 ? "1×" : `${playbackRate}×`}</span>
+                  <span className="ml-1">
+                    {playbackRate === 1 ? "1×" : `${playbackRate}×`}
+                  </span>
                 </DropdownMenuTrigger>
               }
             />
@@ -219,18 +266,24 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
               align="center"
               className="min-w-[6rem]"
             >
-              <DropdownMenuLabel>Speed</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuRadioGroup
-                value={String(playbackRate)}
-                onValueChange={handlePlaybackRateChange}
-              >
-                {PLAYBACK_RATES.map((rate) => (
-                  <DropdownMenuRadioItem key={rate} value={String(rate)} className="cursor-pointer font-mono text-sm">
-                    {rate === 1 ? "Normal" : `${rate}×`}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Speed</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuRadioGroup
+                  value={String(playbackRate)}
+                  onValueChange={handlePlaybackRateChange}
+                >
+                  {PLAYBACK_RATES.map((rate) => (
+                    <DropdownMenuRadioItem
+                      key={rate}
+                      value={String(rate)}
+                      className="cursor-pointer font-mono text-sm"
+                    >
+                      {rate === 1 ? "Normal" : `${rate}×`}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuGroup>
             </DropdownMenuContent>
           </DropdownMenu>
           <TooltipContent
@@ -240,7 +293,13 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
             Playback Speed
           </TooltipContent>
         </Tooltip>
-        <Tooltip key={isFullscreen ? "fullscreen-toggle:active" : "fullscreen-toggle:inactive"}>
+        <Tooltip
+          key={
+            isFullscreen
+              ? "fullscreen-toggle:active"
+              : "fullscreen-toggle:inactive"
+          }
+        >
           <TooltipTrigger
             render={
               <VideoControlButton onClick={handleFullscreenToggle}>
@@ -250,9 +309,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
           />
           <TooltipContent
             className="text-white"
-            container={
-              isFullscreen ? containerRef.current : document.body
-            }
+            container={isFullscreen ? containerRef.current : document.body}
           >
             {!isFullscreen ? "Enter Fullscreen" : "Exit Fullscreen"}
           </TooltipContent>

--- a/src/components/VideoPlayer/window.tsx
+++ b/src/components/VideoPlayer/window.tsx
@@ -82,6 +82,25 @@ export function VideoPlayerWindow({
     )
       return;
 
+    if (e.key === "Escape") {
+      const { isSpeedMenuOpen, isVolumeMenuOpen, isFullscreen } = store.getState().state.events;
+      if (isSpeedMenuOpen) {
+        e.preventDefault();
+        store.getState().actions.setEvent("isSpeedMenuOpen", false);
+        return;
+      }
+      if (isVolumeMenuOpen) {
+        e.preventDefault();
+        store.getState().actions.setEvent("isVolumeMenuOpen", false);
+        return;
+      }
+      if (isFullscreen) {
+        e.preventDefault();
+        void document.exitFullscreen();
+      }
+      return;
+    }
+
     e.preventDefault();
 
     if (e.key === " ") {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -22,14 +22,16 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 4,
   className,
+  container,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > &
+  Pick<MenuPrimitive.Portal.Props, "container">) {
   return (
-    <MenuPrimitive.Portal>
+    <MenuPrimitive.Portal container={container}>
       <MenuPrimitive.Positioner
         className="isolate z-50 outline-none"
         align={align}

--- a/src/lib/stores/video.ts
+++ b/src/lib/stores/video.ts
@@ -14,6 +14,7 @@ export type VideoPlayerState = {
     isWaiting: boolean;
     isFullscreen: boolean;
     isVolumeMenuOpen: boolean;
+    isSpeedMenuOpen: boolean;
     fullscreenTransition: boolean;
   };
   values: {
@@ -21,6 +22,7 @@ export type VideoPlayerState = {
     duration: number;
     volume: number;
     buffered: number;
+    playbackRate: number;
     iconFlash: IconFlash;
     autoPlay: boolean;
     muted: boolean;
@@ -58,6 +60,7 @@ export const initialState: VideoPlayerState = {
     isWaiting: false,
     isFullscreen: false,
     isVolumeMenuOpen: false,
+    isSpeedMenuOpen: false,
     fullscreenTransition: false,
   },
   values: {
@@ -65,6 +68,7 @@ export const initialState: VideoPlayerState = {
     duration: 0,
     volume: 0.5,
     buffered: 0,
+    playbackRate: 1,
     iconFlash: EMPTY,
     autoPlay: false,
     muted: false,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,3 @@
 export const EMPTY: unique symbol = Symbol("empty");
 export const VIDEO_PLAYER_VOLUME = "video_player_volume" as const;
+export const PLAYBACK_RATES = [0.5, 0.75, 1, 1.5, 2] as const;


### PR DESCRIPTION
## Summary
UI-only additions on top of @VEDA95's video player architecture — no new hooks or stores were created beyond extending the existing zustand store; all changes integrate with existing contexts and `usePlayToggle`.

### What changed
- **`src/lib/stores/video.ts`**: `playbackRate` in values; `isSpeedMenuOpen` in events
- **`src/utils/constants.ts`**: `PLAYBACK_RATES`
- **`controls.tsx`**: Speed dropdown (0.5×–2×) via shadcn `DropdownMenuRadioGroup` between volume and fullscreen
- **`window.tsx`**: Escape closes speed menu → volume menu → exits fullscreen
- **`container.tsx`**: Mobile full-bleed + rotate hint (hidden in landscape)

### Review
@VEDA95 — please review store additions and Escape handling.

`pnpm run build` passes locally.

Made with [Cursor](https://cursor.com)