### PR TITLE
Update video player design and interaction behavior

### DIFF
--- a/src/components/VideoPlayer/container.tsx
+++ b/src/components/VideoPlayer/container.tsx
@@ -18,7 +18,7 @@ export function VideoPlayerContainer({
   const isFullscreen = useVideoPlayerContext<boolean>(
     (state: VideoPlayerStore): boolean => state.state.events.isFullscreen,
   );
-  const containerClasses: string = cn("relative overflow-visible", className, {
+  const containerClasses: string = cn("relative aspect-video overflow-visible", className, {
     "rounded-none": isFullscreen,
     "rounded-xl": !isFullscreen,
   });

--- a/src/components/VideoPlayer/controls.tsx
+++ b/src/components/VideoPlayer/controls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, forwardRef } from "react";
+import { useCallback, useRef, forwardRef } from "react";
 import { useVideoPlayerContext, useVideoPlayerRefs } from "@lib/contexts/video";
 import { usingMobilePointer } from "@lib/mobile";
 import { usePlayToggle } from "@hooks/use-play-toggle";
@@ -10,11 +10,18 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuRad
 import { cn } from "@utils/classMerge";
 import { formatTime } from "@utils/format";
 import { VIDEO_PLAYER_VOLUME, PLAYBACK_RATES } from "@utils/constants";
-import type { ReactElement, FC, PropsWithChildren } from "react";
+import type { ReactElement, FC, PropsWithChildren, PointerEvent } from "react";
 import type { VideoPlayerStore, VideoPlayerActions } from "@lib/stores/video";
+
+const videoControlSurfaceClasses = "border-white/15 bg-black/60 text-white backdrop-blur-md hover:bg-black/75 hover:text-white focus-visible:border-white/40 focus-visible:ring-white/40 aria-expanded:bg-black/80 aria-expanded:text-white";
+const videoMenuSurfaceClasses = "border border-white/15 bg-black/70 text-white ring-white/15 backdrop-blur-md";
+const progressSliderClasses = "[&_[data-slot=slider-track]]:bg-mango-yellow-light [&_[data-slot=slider-buffer]]:bg-mango-yellow-light/70 [&_[data-slot=slider-range]]:bg-mango-yellow [&_[data-slot=slider-thumb]]:border-mango-green-light [&_[data-slot=slider-thumb]]:bg-mango-green-light [&_[data-slot=slider-thumb]]:ring-mango-green-light/40 [&_[data-slot=slider-thumb]:hover]:ring-mango-green-light/35 [&_[data-slot=slider-hover-tooltip]]:bg-black/75 [&_[data-slot=slider-hover-tooltip]]:text-white";
+const volumeSliderClasses = "[&_[data-slot=slider-track]]:bg-white/25 [&_[data-slot=slider-range]]:bg-white [&_[data-slot=slider-thumb]]:border-white [&_[data-slot=slider-thumb]]:bg-white [&_[data-slot=slider-thumb]]:ring-white/40 [&_[data-slot=slider-thumb]:hover]:ring-white/35";
 
 export interface VideoControlButtonProps extends PropsWithChildren {
   onClick?: () => void;
+  onPointerDown?: (event: PointerEvent<HTMLButtonElement>) => void;
+  onPointerUp?: (event: PointerEvent<HTMLButtonElement>) => void;
   className?: string;
 }
 
@@ -28,7 +35,7 @@ export const VideoControlButton = forwardRef<
       type="button"
       size="sm"
       onClick={onClick}
-      className={cn("cursor-pointer", className)}
+      className={cn("cursor-pointer", videoControlSurfaceClasses, className)}
       {...props}
     >
       {children}
@@ -52,6 +59,27 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
   const duration = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.duration);
   const volume = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.volume);
   const buffered = useVideoPlayerContext<number>((store: VideoPlayerStore): number => store.state.values.buffered);
+  const speedMenuViewportRef = useRef({ x: 0, y: 0 });
+  const rememberSpeedMenuViewport = useCallback((): void => {
+    speedMenuViewportRef.current = { x: window.scrollX, y: window.scrollY };
+  }, []);
+  const restoreSpeedMenuViewport = useCallback((wasFullscreen = false): void => {
+    const { x, y } = speedMenuViewportRef.current;
+
+    requestAnimationFrame((): void => {
+      window.scrollTo(x, y);
+
+      if (
+        wasFullscreen &&
+        document.fullscreenElement == null &&
+        containerRef.current != null
+      ) {
+        void containerRef.current.requestFullscreen().catch(() => undefined);
+      }
+
+      requestAnimationFrame((): void => window.scrollTo(x, y));
+    });
+  }, []);
   const handleTrackChange = useCallback(
     (value: number | readonly number[]): void => {
       if (videoRef.current == null) return;
@@ -90,15 +118,20 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
     [],
   );
   const handleSpeedMenuOpen = useCallback(
-    (open: boolean): void => setEvent("isSpeedMenuOpen", open),
+    (open: boolean): void => {
+      setEvent("isSpeedMenuOpen", open);
+      restoreSpeedMenuViewport();
+    },
     [],
   );
   const handlePlaybackRateChange = useCallback(
     (value: string): void => {
       if (videoRef.current == null) return;
+      const wasFullscreen = document.fullscreenElement != null;
       const rate = parseFloat(value);
       videoRef.current.playbackRate = rate;
       setValue("playbackRate", rate);
+      restoreSpeedMenuViewport(wasFullscreen);
     },
     [],
   );
@@ -146,7 +179,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
             {isPlaying ? "Pause" : "Play"}
           </TooltipContent>
         </Tooltip>
-        <div className="inline-flex justify-center w-10">
+        <div className="inline-flex w-12 justify-center rounded-md bg-black/60 px-2 py-1 text-white backdrop-blur-md">
           <span className="text-white text-sm">
             {formatTime(time)}
           </span>
@@ -159,7 +192,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
           value={time}
           bufferValue={buffered}
           onValueChange={handleTrackChange}
-          className="cursor-pointer"
+          className={cn("cursor-pointer", progressSliderClasses)}
         />
       </div>
       <div className="grid grid-flow-col items-center justify-center gap-x-1">
@@ -181,7 +214,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
               container={containerRef}
               side="top"
               align="center"
-              className="min-w-none w-8"
+              className={cn("min-w-none w-8", videoMenuSurfaceClasses)}
             >
               <Slider
                 orientation="vertical"
@@ -189,7 +222,7 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
                 step={0.01}
                 value={volume}
                 onValueChange={handleVolumeChange}
-                className="cursor-pointer"
+                className={cn("cursor-pointer", volumeSliderClasses)}
               />
             </DropdownMenuContent>
           </DropdownMenu>
@@ -207,7 +240,15 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
           >
             <TooltipTrigger
               render={
-                <DropdownMenuTrigger render={<VideoControlButton className="font-mono text-xs" />}>
+                <DropdownMenuTrigger
+                  render={
+                    <VideoControlButton
+                      className="font-mono text-xs"
+                      onPointerDown={rememberSpeedMenuViewport}
+                      onPointerUp={() => restoreSpeedMenuViewport()}
+                    />
+                  }
+                >
                   <Gauge className="size-4" />
                   <span className="ml-1">{playbackRate === 1 ? "1×" : `${playbackRate}×`}</span>
                 </DropdownMenuTrigger>
@@ -217,16 +258,22 @@ export function VideoPlayerControlBar(): ReactElement<FC> {
               container={containerRef}
               side="top"
               align="center"
-              className="min-w-[6rem]"
+              className={cn("min-w-[6rem]", videoMenuSurfaceClasses)}
             >
-              <DropdownMenuLabel>Speed</DropdownMenuLabel>
-              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-white/70">Speed</DropdownMenuLabel>
+              <DropdownMenuSeparator className="bg-white/20" />
               <DropdownMenuRadioGroup
                 value={String(playbackRate)}
                 onValueChange={handlePlaybackRateChange}
               >
                 {PLAYBACK_RATES.map((rate) => (
-                  <DropdownMenuRadioItem key={rate} value={String(rate)} className="cursor-pointer font-mono text-sm">
+                  <DropdownMenuRadioItem
+                    key={rate}
+                    value={String(rate)}
+                    onPointerDown={rememberSpeedMenuViewport}
+                    onPointerUp={() => restoreSpeedMenuViewport()}
+                    className="cursor-pointer font-mono text-sm text-white focus:bg-white/15 focus:text-white focus:**:text-white data-checked:bg-white/15 data-checked:text-white"
+                  >
                     {rate === 1 ? "Normal" : `${rate}×`}
                   </DropdownMenuRadioItem>
                 ))}

--- a/src/components/VideoPlayer/window.tsx
+++ b/src/components/VideoPlayer/window.tsx
@@ -153,14 +153,14 @@ export function VideoPlayerWindow({
     setValue("duration", videoRef.current.duration);
   }, []);
   const posterClasses: string = cn(
-    "absolute inset-0 w-full h-auto object-cover aspect-video z-10 pointer-events-none",
+    "absolute inset-0 h-full w-full object-cover z-10 pointer-events-none",
     {
       "rounded-none": isFullscreen,
       "rounded-xl": !isFullscreen,
     },
   );
   const videoClasses: string = cn(
-    "w-full h-auto aspect-video object-cover z-0",
+    "block h-full w-full object-cover z-0",
     {
       "rounded-none": isFullscreen,
       "rounded-xl": !isFullscreen,


### PR DESCRIPTION
## Summary
- Applies the video player design update first: transparent black controls/menus, white text/icons, mango yellow progress, mango yellow light track, mango green light scrubber, and white volume slider states.
- Fixes mobile playback layout by keeping the video/player surface in a stable aspect-ratio container when the poster is removed after play.
- Preserves viewport position around playback-speed interactions and keeps fullscreen recovery guarded for speed changes.

## Review order for Stefan / VEDA95
1. Review the design change first.
2. Review the functional bug fixes second.

## Issue
Refs #11

## Test plan
- npm run build
- Checked linter diagnostics for edited video player files.
- Browser checked mobile-width playback so the player remains visible after pressing play.
- Browser checked speed control interactions around the video player viewport.

Made with [Cursor](https://cursor.com)