### PR TITLE
Update sidebar.tsx to add aria-label

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -203,6 +203,7 @@ function SidebarTrigger({
     <Button
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
+      aria-label="Toggle Sidebar"
       variant="ghost"
       size="icon-lg"
       className={cn(


### PR DESCRIPTION
The sidebar open button on mobile was missing an aria label. Added it in this commit.

<img width="1134" height="372" alt="image" src="https://github.com/user-attachments/assets/64296ebf-f99e-42b7-8cfe-a3b8f09a5e90" />
 
